### PR TITLE
Issue47

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 
 .env
+.idea
 */**/__pycache__
 db.sqlite3

--- a/dayplanner/services/yelp_client.py
+++ b/dayplanner/services/yelp_client.py
@@ -33,7 +33,7 @@ def fetch_by_id(yelp_id):
 # output: List of python dict
 def fetch_many(yelp_ids):
     responses = []
-    # A single connection can reuse the same TCP connection between requests
+    # A single conn can reuse the same TCP connection between requests
     with requests.Session() as conn:
         for yelp_id in yelp_ids:
             if yelp_id in Detail_cache:

--- a/dayplanner/services/yelp_client.py
+++ b/dayplanner/services/yelp_client.py
@@ -82,6 +82,7 @@ class YelpRequest:
     def __init__(self,endpoint,params={},conn=None):
         self.endpoint = endpoint
         self.params = params
+        self.conn = conn
         self.headers = {'Authorization': 'Bearer %s' % YELP_API}
 
     def execute(self):

--- a/dayplanner/services/yelp_client.py
+++ b/dayplanner/services/yelp_client.py
@@ -37,10 +37,8 @@ def fetch_many(yelp_ids):
     with requests.Session() as conn:
         for yelp_id in yelp_ids:
             if yelp_id in Detail_cache:
-                print("Cache Hit!")
                 responses.append(Detail_cache[yelp_id])
             else:
-                print("Cache Miss!")
                 req = YelpRequest(
                     endpoint=Detail_endpoint % yelp_id,
                     conn=conn

--- a/dayplanner/services/yelp_client.py
+++ b/dayplanner/services/yelp_client.py
@@ -2,28 +2,29 @@ import requests, json
 from dayplanner.settings import YELP_API
 
 key ='CL1ez7IjEGAsK5LINl-ehN8lTuQSaOqP8NncZD0e8JRLcOmmACCc3u87rtD7l1Bwpc9uzwQF8Oj2K6lo7f9cHo2P6xhlCFSI6Thph0MaRgRDcM4XA6iww7AX8QROYXYx'
-Search_endpoint = 'https://api.yelp.com/v3/businesses/search'
-Detail_endpoint = 'https://api.yelp.com/v3/businesses/%s'
+search_endpoint = 'https://api.yelp.com/v3/businesses/search'
+detail_endpoint = 'https://api.yelp.com/v3/businesses/%s'
+
 search_cache = {}
-Detail_cache = {}
+detail_cache = {}
 
 
 # input: yelp id
 # output will be a python dict
 def fetch_by_id(yelp_id):
-    if yelp_id in Detail_cache:
+    if yelp_id in detail_cache:
         print("Cache Hit!")
-        return Detail_cache[yelp_id]
+        return detail_cache[yelp_id]
 
     print("Cache Miss!")
 
     req = YelpRequest(
-        endpoint=Detail_endpoint % yelp_id,
+        endpoint=detail_endpoint % yelp_id,
     )
 
     response = req.execute()
 
-    Detail_cache[yelp_id] = response
+    detail_cache[yelp_id] = response
 
     return response
 
@@ -36,15 +37,15 @@ def fetch_many(yelp_ids):
     # A single conn can reuse the same TCP connection between requests
     with requests.Session() as conn:
         for yelp_id in yelp_ids:
-            if yelp_id in Detail_cache:
-                responses.append(Detail_cache[yelp_id])
+            if yelp_id in detail_cache:
+                responses.append(detail_cache[yelp_id])
             else:
                 req = YelpRequest(
-                    endpoint=Detail_endpoint % yelp_id,
+                    endpoint=detail_endpoint % yelp_id,
                     conn=conn
                 )
                 response = req.execute()
-                Detail_cache[yelp_id] = response
+                detail_cache[yelp_id] = response
                 responses.append(response)
     
     return responses
@@ -62,7 +63,7 @@ def search(location):
 
     print("Cache Missed")
     req = YelpRequest(
-        endpoint= Search_endpoint ,
+        endpoint= search_endpoint ,
         params= {'term':'coffee', 'limit':5, 'radius': 10000,'location': location},
     )
     # search Result is a python dict in the form of YELP JSON

--- a/resources/venues/models.py
+++ b/resources/venues/models.py
@@ -7,5 +7,11 @@ class Venue(models.Model):
 
     def raw_yelp_data(self):
         return yelp_client.fetch_by_id(self.yelp_id)
+
+    def yelp__name(self):
+        return self.raw_yelp_data()['name']
+
+    def yelp__image_url(self):
+        return self.raw_yelp_data()['image_url']
         
 

--- a/resources/venues/models.py
+++ b/resources/venues/models.py
@@ -1,10 +1,11 @@
 from django.db import models
+from dayplanner.services import yelp_client
 
 # Create your models here.
 class Venue(models.Model):
     yelp_id = models.CharField(max_length=100,unique=True)
 
-    @staticmethod
-    def for_yelp_id(yelp_id):
-        venue, created = Venue.objects.get_or_create(yelp_id=yelp_id)
-        return venue if created else False
+    def raw_yelp_data(self):
+        return yelp_client.fetch_by_id(self.yelp_id)
+        
+

--- a/resources/venues/templates/venues/_detail.html
+++ b/resources/venues/templates/venues/_detail.html
@@ -1,5 +1,17 @@
 <p>
-    {{ name }}
+    Venue ID: {{ venue.id }}
 </p>
 
-<img src="{{ image_url }}" height="400">
+<p>
+    Yelp ID: {{ venue.yelp_id }}
+</p>
+
+Details from Yelp:
+
+<p>
+    <img src="{{raw_yelp_data.image_url }}" height="400">
+</p>
+
+<pre>
+    {{raw_yelp_data}}
+</pre>

--- a/resources/venues/templates/venues/_index.html
+++ b/resources/venues/templates/venues/_index.html
@@ -3,9 +3,30 @@
 </p>
 
 <ul>
-    {% for venue in venues.iterator %}
-        <li>
-            Yelp ID: {{venue.yelp_id}}
-        </li>
-    {% endfor %}
+
 </ul>
+
+<table>
+    <tr>
+      <th>ID</th>
+      <th>Yelp ID</th> 
+      <th>Name</th>
+      <th>Image</th>
+    </tr>
+    {% for venue in venues.iterator %}
+    <tr>
+        <td>
+            {{venue.id}}
+        </td>
+        <td>
+            {{venue.yelp_id}}
+        </td>
+        <td>
+            {{venue.yelp__name}}
+        </td>
+        <td>
+            <img src="{{venue.yelp__image_url}}" height="50">
+        </td>
+    </tr>
+    {% endfor %}
+  </table>

--- a/resources/venues/templates/venues/_sample_yelp_single_output.html
+++ b/resources/venues/templates/venues/_sample_yelp_single_output.html
@@ -1,0 +1,14 @@
+<p>
+    Sample Yelp Output
+</p>
+
+
+<p>
+    {{ data.name }}
+</p>
+
+<img src="{{ data.image_url }}" height="400">
+
+<pre>
+    {{data}}
+</pre>

--- a/resources/venues/urls.py
+++ b/resources/venues/urls.py
@@ -5,7 +5,8 @@ app_name = 'resources.venues'
 
 urlpatterns = [
     path('', views.index, name='index'),
-    #path('for_yelp_id/<str:yelp_id>', views.get_detail_yelpID(), name='sampleYelpOutput'),
+    path('<int:venue_id>', views.detail),
+    # path('for_yelp_id/<str:yelp_id>', views.sample_yelp_output(), name='sample_yelp_output'),
+    path('for_yelp_id/<str:yelp_id>', views.sample_yelp_single_output, name='sample_yelp_single_output'),
     path('search',views.search_view),
-    path('detail/<str:yelp_id>', views.detail)
 ]

--- a/resources/venues/views.py
+++ b/resources/venues/views.py
@@ -1,5 +1,5 @@
 from django.db.models import Model
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from dayplanner.services import yelp_client
 import requests, json, os
 from dayplanner.settings import YELP_API
@@ -13,10 +13,13 @@ def index(request):
         'venues': Venue.objects.all()
     })
 
-def detail(request, yelp_id):
-    business_detail = yelp_client.fetch_by_id(yelp_id)
-
-    return render(request, 'venues/_detail.html', business_detail)
+def detail(request, venue_id):
+    venue = get_object_or_404(Venue, pk=venue_id)
+    context = {
+        'venue': venue,
+        'raw_yelp_data': venue.raw_yelp_data()
+    }
+    return render(request, 'venues/_detail.html', context)
 
 def search_view(request):
 
@@ -42,26 +45,9 @@ def search_view(request):
 
 
 
-
-
-
-
-
-
-
-def getYelp_id():
-    return None
-
-
-
-
-
-def sampleYelpOutput(request, yelp_id):
-    headers = {'Authorization': 'Bearer %s' % YELP_API}
-    url = 'https://api.yelp.com/v3/businesses/%s' % yelp_id
-    response = requests.get(url, headers = headers)
-    business_date = response.json()
-    businessStr = json.dumps(business_date, indent = 3)
-    return render(request, 'venues/_sample_yelp_output.html', {
-        'data': businessStr
-    })
+def sample_yelp_single_output(request, yelp_id):
+    venue, is_created = Venue.objects.get_or_create(yelp_id=yelp_id)
+    context = {
+        'data': venue.raw_yelp_data()
+    }
+    return render(request, 'venues/_sample_yelp_single_output.html', context)


### PR DESCRIPTION
Developed a `yelp_client` service, added some additional methods to the `Venue` model, and created templates to view both single Venues or a list of venues.

To populate your database with Venues easily, navigate to `/resources/venues/for_yelp_id/<some_yelp_id>`.  Each time you load a page like this, a venue is created in the database with the specified `yelp_id` in the url.  You can use `WavvLdfdP6g8aZTtbBQHTw` and `H4jJ7XB3CetIr1pg56CczQ` as examples.

There are two other RESTful urls - `/resources/venues` and `/resources/venues/<primary_key>`, which will show you a list of all venues in the database, or a detail page for a particular venue, respectively.  Each page loads data from yelp.

