### PR TITLE
Fix settings bugs

### DIFF
--- a/dayplanner/settings.py
+++ b/dayplanner/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 from dotenv import load_dotenv, find_dotenv
+import django_heroku
 
 from pathlib import Path
 import os
@@ -160,7 +161,5 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-if "/app" in os.environ["HOME"]:
-    import django_heroku
 
-    django_heroku.settings(locals())
+django_heroku.settings(locals(), test_runner=False)


### PR DESCRIPTION
There were a couple of bugs in the settings files that I fixed in this PR.

1. We didn't have `127.0.0.1` added to allowed hosts - we should have it there.
2. There's was an error for some operating systems for the `django_heroku` guard condition.  @azraf-a found the bug, and offered a fix.