### PR TITLE
hotfix for correct profile page link

### DIFF
--- a/profilepage/views.py
+++ b/profilepage/views.py
@@ -19,7 +19,7 @@ class ProfileView(DetailView):
             curr_user = get_object_or_404(Profile, user=self.request.user)
             context["curr_user"] = curr_user
 
-        page_user = get_object_or_404(Profile, id=self.kwargs["pk"])
+        page_user = get_object_or_404(Profile, user_id=self.kwargs["pk"])
 
         context["page_user"] = page_user
 


### PR DESCRIPTION
we used to find the profile page for {{user.id == profile.id}}
But sometimes {{profile.id}} does not match {{user.id}} even if we automatically  create profile when a user is created.
Fix that with matching {user.id == profile.user.id}