### PR TITLE
fix docker compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ script:
   - flake8
   - python manage.py collectstatic
   - coverage run --source='.' manage.py test
-  - docker compose run web python manage.py check
-  - docker compose run web python manage.py migrate
-  - docker compose up
-  - docker compose down
+  - docker-compose run web python manage.py check
+  - docker-compose run web python manage.py migrate
+  - docker-compose up
+  - docker-compose down
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ python:
 
 env:
   - DOCKER_COMPOSE_VERSION=3.3
+
+services:
+  - docker
+
 before-install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   - pip install coveralls
-
 
 script:
   - black --check .

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ script:
   - coverage run --source='.' manage.py test
   - docker-compose run web python manage.py check
   - docker-compose run web python manage.py migrate
-  - docker-compose up
-  - docker-compose down
 
 after_success:
   - coveralls


### PR DESCRIPTION
Couple of issues here - first of all, `compose` was never supported in this version of docker.  I'm not sure why different versions of docker support the `compose` command and others don't - I think for some reason on linux there is sometimes no `compose` command.  You can see that this was always the case in our previous logs - `compose` never did anything! lol.

Instead, there is a different program called `docker-compose`.  Once I switched to that, it because clear that calling `up` and `down` gets tricky because you need a way to kill the process.  So I removed those commands.

Anyhow - seems to work now!